### PR TITLE
Add GKE support

### DIFF
--- a/envs/gke/dashboard-backend-config.yaml
+++ b/envs/gke/dashboard-backend-config.yaml
@@ -1,0 +1,14 @@
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: wazuh-beconfig
+  namespace: wazuh
+spec:
+  healthCheck:
+    checkIntervalSec: 120
+    timeoutSec: 15
+    healthyThreshold: 1
+    unhealthyThreshold: 2
+    type: HTTPS
+    requestPath: "/app/login?"
+    

--- a/envs/gke/dashboard-loadbalancer.yaml
+++ b/envs/gke/dashboard-loadbalancer.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dashboard
+  namespace: wazuh
+  labels:
+    app: wazuh-dashboard
+  annotations:
+    cloud.google.com/backend-config: '{"default":"wazuh-beconfig"}'
+    cloud.google.com/neg: '{"ingress": true}'
+    cloud.google.com/app-protocols: '{"dashboard-https-port":"HTTPS"}'
+spec:
+  type: NodePort
+  selector:
+    app: wazuh-dashboard
+  ports:
+  - name: dashboard-https-port
+    port: 443
+    targetPort: 5601

--- a/envs/gke/dashboard-resources.yaml
+++ b/envs/gke/dashboard-resources.yaml
@@ -1,0 +1,24 @@
+# Copyright (C) 2019, Wazuh Inc.
+#
+# This program is a free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wazuh-dashboard
+  namespace: wazuh
+spec:
+  template:
+    spec:
+      containers:
+        - name: wazuh-dashboard
+          resources:
+            requests:
+              cpu: 200m
+              memory: 512Mi
+            limits:
+              cpu: 400m
+              memory: 2Gi

--- a/envs/gke/https-loadbalancer.yaml
+++ b/envs/gke/https-loadbalancer.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wazuh-dashboard-ingress
+  namespace: wazuh
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: ADDRESS_NAME
+    networking.gke.io/managed-certificates: CERT_NAME
+    kubernetes.io/ingress.class: "gce"
+    kubernetes.io/ingress.allow-http: "true"
+    networking.gke.io/v1beta1.FrontendConfig: "dashboard-frontend"
+spec:
+  defaultBackend:
+    service:
+      name: dashboard
+      port:
+        number: 443

--- a/envs/gke/indexer-autopilot.yaml
+++ b/envs/gke/indexer-autopilot.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: wazuh-indexer
+  namespace: wazuh
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: increase-the-vm-max-map-count
+          image: busybox
+          command: ['sh', '-c', "while true; do mmc=$(cat /proc/sys/vm/max_map_count); if [ ${mmc} -eq 262144 ]; then exit 0; fi; sleep 1; done"]
+          securityContext:
+            privileged: false

--- a/envs/gke/indexer-resources.yaml
+++ b/envs/gke/indexer-resources.yaml
@@ -1,0 +1,35 @@
+# Copyright (C) 2019, Wazuh Inc.
+#
+# This program is a free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: wazuh-indexer
+  namespace: wazuh
+spec:
+  template:
+    spec:
+      containers:
+        - name: wazuh-indexer
+          resources:
+            requests:
+              cpu: 500m
+              memory: 2Gi
+            limits:
+              cpu: 1
+              memory: 4Gi
+  volumeClaimTemplates:
+    - metadata:
+        name: wazuh-indexer
+        namespace: indexer-cluster
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: wazuh-storage
+        resources:
+          requests:
+            storage: 10Gi

--- a/envs/gke/ingress-ssl-cert.yaml
+++ b/envs/gke/ingress-ssl-cert.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: managed-cert
+spec:
+  domains:
+    - FQDN_1
+
+---
+apiVersion: networking.gke.io/v1beta1
+kind: FrontendConfig
+metadata:
+  name: dashboard-frontend
+spec:
+  sslPolicy: wazuh-dashboard-ssl-policy
+  redirectToHttps:
+    enabled: true

--- a/envs/gke/kustomization.yml
+++ b/envs/gke/kustomization.yml
@@ -1,0 +1,23 @@
+# Copyright (C) 2019, Wazuh Inc.
+#
+# This program is a free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../wazuh
+- mem-count-daemonset.yaml
+- https-loadbalancer.yaml
+- dashboard-backend-config.yaml
+- ingress-ssl-cert.yaml
+patches:
+- path: storage-class.yaml
+- path: indexer-autopilot.yaml
+- path: indexer-resources.yaml
+- path: dashboard-resources.yaml
+- path: wazuh-master-resources.yaml
+- path: wazuh-worker-resources.yaml
+- path: dashboard-loadbalancer.yaml

--- a/envs/gke/mem-count-daemonset.yaml
+++ b/envs/gke/mem-count-daemonset.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: max-map-count-setter
+  labels:
+    k8s-app: max-map-count-setter
+spec:
+  selector:
+    matchLabels:
+      name: max-map-count-setter
+  template:
+    metadata:
+      labels:
+        name: max-map-count-setter
+    spec:
+      initContainers:
+        - name: max-map-count-setter
+          image: docker.io/bash:5.2.15
+          resources:
+            limits:
+              cpu: 100m
+              memory: 32Mi
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          command: ['/usr/local/bin/bash', '-e', '-c', 'echo 262144 > /proc/sys/vm/max_map_count']
+      containers:
+        - name: sleep
+          image: docker.io/bash:5.2.15
+          command: ['sleep', 'infinity']

--- a/envs/gke/storage-class.yaml
+++ b/envs/gke/storage-class.yaml
@@ -1,0 +1,12 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: wazuh-storage
+provisioner: kubernetes.io/gce-pd
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+reclaimPolicy: Retain
+parameters:
+  type: pd-standard
+  fstype: ext4
+  replication-type: none

--- a/envs/gke/wazuh-master-resources.yaml
+++ b/envs/gke/wazuh-master-resources.yaml
@@ -1,0 +1,35 @@
+# Copyright (C) 2019, Wazuh Inc.
+#
+# This program is a free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: wazuh-manager-master
+  namespace: wazuh
+spec:
+  template:
+    spec:
+      containers:
+        - name: wazuh-manager
+          resources:
+            requests:
+              cpu: 1
+              memory: 1Gi
+            limits:
+              cpu: 2
+              memory: 2Gi
+  volumeClaimTemplates:
+    - metadata:
+        name: wazuh-manager-master
+        namespace: wazuh
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: wazuh-storage
+        resources:
+          requests:
+            storage: 50Gi

--- a/envs/gke/wazuh-worker-resources.yaml
+++ b/envs/gke/wazuh-worker-resources.yaml
@@ -1,0 +1,35 @@
+# Copyright (C) 2019, Wazuh Inc.
+#
+# This program is a free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: wazuh-manager-worker
+  namespace: wazuh
+spec:
+  template:
+    spec:
+      containers:
+        - name: wazuh-manager
+          resources:
+            requests:
+              cpu: 1
+              memory: 1Gi
+            limits:
+              cpu: 2
+              memory: 2Gi
+  volumeClaimTemplates:
+    - metadata:
+        name: wazuh-manager-worker
+        namespace: wazuh
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: wazuh-storage
+        resources:
+          requests:
+            storage: 50Gi

--- a/wazuh/wazuh_managers/wazuh-workers-svc.yaml
+++ b/wazuh/wazuh_managers/wazuh-workers-svc.yaml
@@ -18,6 +18,7 @@ metadata:
   annotations:
     # domainName: 'wazuh-manager.some-domain.com'  # TODO: Change this for a Hosted Zone you configured in AWS Route 53
     service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
+    cloud.google.com/l4-rbs: "enabled"
 spec:
   type: LoadBalancer
   selector:


### PR DESCRIPTION
This adds the necessary static configuration for the wazuh-deployment to work on GKE Autopilot, including SSL for ingress, and other GKE specific changes.

Some of the options are then overriden from terraform (anything IN ALL CAPS), to provide the cluster-specific details.
